### PR TITLE
ホーム画面に表示する問題のプレビューコンポーネントを作成　Front/30

### DIFF
--- a/front/src/components/QuestionPreview.vue
+++ b/front/src/components/QuestionPreview.vue
@@ -1,0 +1,76 @@
+<template>
+  <div class="question-preview">
+    <div
+      class="question-preview-header"
+      v-if="question.questionType === 'anaume'"
+    >
+      <h3>icon</h3>
+      <h3>穴埋め問題</h3>
+    </div>
+    <div
+      class="question-preview-header"
+      v-else-if="question.questionType === '4taku'"
+    >
+      <h3>icon</h3>
+      <h3>四択問題</h3>
+    </div>
+
+    <div
+      class="question-preview-header"
+      v-else-if="question.questionType === 'collection'"
+    >
+      <h3>icon</h3>
+      <h3>問題集</h3>
+    </div>
+
+    <div class="question-preview-header" v-else>unknown</div>
+
+    <div class="question-preview-footer">
+      <div class="question-preview-title">「{{ question.name }}」</div>
+      <div class="question-preview-info">
+        <div class="question-preview-author">
+          {{ question.author.displayName }}
+        </div>
+        <div class="question-preview-updatetime">
+          {{ question.updateTime }}
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+// import '@/components/icons/IconQuestion4taku.vue'
+
+export default {
+  name: 'QuestionPreview',
+  props: ['question'],
+  components: {},
+}
+</script>
+
+<style scoped>
+.question-preview {
+  width: 350px;
+  height: 180px;
+  background-color: aquamarine;
+  display: flex;
+  flex-flow: column;
+  justify-content: space-between;
+}
+
+.question-preview-header {
+  display: flex;
+  flex-flow: row;
+  justify-content: space-between;
+  padding: 20px;
+}
+
+.question-preview-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+</style>

--- a/front/src/components/QuestionPreview.vue
+++ b/front/src/components/QuestionPreview.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="question-preview">
+    
     <div
       class="question-preview-header"
       v-if="question.questionType === 'anaume'"
@@ -7,6 +8,7 @@
       <IconQuestionAnaume :width="100" :height="100" />
       <h3>穴埋め問題</h3>
     </div>
+
     <div
       class="question-preview-header"
       v-else-if="question.questionType === '4taku'"
@@ -22,8 +24,6 @@
       <IconQuestionCollection :width="100" :height="100" />
       <h3>問題集</h3>
     </div>
-
-    <div class="question-preview-header" v-else>unknown</div>
 
     <div class="question-preview-footer">
       <div class="question-preview-title">「{{ question.name }}」</div>

--- a/front/src/components/QuestionPreview.vue
+++ b/front/src/components/QuestionPreview.vue
@@ -1,6 +1,5 @@
 <template>
   <div class="question-preview">
-    
     <div
       class="question-preview-header"
       v-if="question.questionType === 'anaume'"
@@ -43,6 +42,8 @@
 import IconQuestion4taku from '@/components/icons/IconQuestion4taku.vue'
 import IconQuestionAnaume from '@/components/icons/IconQuestionAnaume.vue'
 import IconQuestionCollection from '@/components/icons/IconQuestionCollection.vue'
+
+// todo : 問題集の名前を埋める
 
 export default {
   name: 'QuestionPreview',

--- a/front/src/components/QuestionPreview.vue
+++ b/front/src/components/QuestionPreview.vue
@@ -4,14 +4,14 @@
       class="question-preview-header"
       v-if="question.questionType === 'anaume'"
     >
-      <h3>icon</h3>
+      <IconQuestionAnaume :width="100" :height="100" />
       <h3>穴埋め問題</h3>
     </div>
     <div
       class="question-preview-header"
       v-else-if="question.questionType === '4taku'"
     >
-      <h3>icon</h3>
+    <IconQuestion4taku :width="100" :height="100" />
       <h3>四択問題</h3>
     </div>
 
@@ -19,7 +19,7 @@
       class="question-preview-header"
       v-else-if="question.questionType === 'collection'"
     >
-      <h3>icon</h3>
+      <IconQuestionCollection :width="100" :height="100" />
       <h3>問題集</h3>
     </div>
 
@@ -40,12 +40,18 @@
 </template>
 
 <script>
-// import '@/components/icons/IconQuestion4taku.vue'
+import IconQuestion4taku from '@/components/icons/IconQuestion4taku.vue'
+import IconQuestionAnaume from '@/components/icons/IconQuestionAnaume.vue'
+import IconQuestionCollection from '@/components/icons/IconQuestionCollection.vue'
 
 export default {
   name: 'QuestionPreview',
   props: ['question'],
-  components: {},
+  components: {
+    IconQuestion4taku,
+    IconQuestionAnaume,
+    IconQuestionCollection,
+  },
 }
 </script>
 

--- a/front/src/components/QuestionPreview.vue
+++ b/front/src/components/QuestionPreview.vue
@@ -11,7 +11,7 @@
       class="question-preview-header"
       v-else-if="question.questionType === '4taku'"
     >
-    <IconQuestion4taku :width="100" :height="100" />
+      <IconQuestion4taku :width="100" :height="100" />
       <h3>四択問題</h3>
     </div>
 

--- a/front/src/components/icons/IconQuestion4taku.vue
+++ b/front/src/components/icons/IconQuestion4taku.vue
@@ -59,16 +59,16 @@
 
 <script>
 export default {
-    name: 'IconQuestion4taku',
-    props: {
-        width: {
-            type: [Number, String],
-            default: 100
-        },
-        height: {
-            type: [Number, String],
-            default: 100
-        }
-    }
+  name: 'IconQuestion4taku',
+  props: {
+    width: {
+      type: [Number, String],
+      default: 100,
+    },
+    height: {
+      type: [Number, String],
+      default: 100,
+    },
+  },
 }
 </script>

--- a/front/src/components/icons/IconQuestion4taku.vue
+++ b/front/src/components/icons/IconQuestion4taku.vue
@@ -1,0 +1,73 @@
+<template>
+  <svg
+    version="1.1"
+    id="&#x30EC;&#x30A4;&#x30E4;&#x30FC;_1"
+    xmlns="http://www.w3.org/2000/svg"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    x="0px"
+    y="0px"
+    viewBox="0 0 100 100"
+    style="enable-background: new 0 0 100 100"
+    xml:space="preserve"
+    :width="width"
+    :height="height"
+  >
+    <g>
+      <path
+        style="
+          fill: #ffffff;
+          stroke: #000000;
+          stroke-width: 3;
+          stroke-miterlimit: 10;
+        "
+        d="M42.743,44.365H23.066c-1.105,0-2-0.895-2-2
+		V22.687c0-1.105,0.895-2,2-2h19.678c1.105,0,2,0.895,2,2v19.678C44.743,43.47,43.848,44.365,42.743,44.365z"
+      />
+      <path
+        style="
+          fill: #ffffff;
+          stroke: #000000;
+          stroke-width: 3;
+          stroke-miterlimit: 10;
+        "
+        d="M76.935,44.365H57.257c-1.105,0-2-0.895-2-2
+		V22.687c0-1.105,0.895-2,2-2h19.678c1.105,0,2,0.895,2,2v19.678C78.935,43.47,78.039,44.365,76.935,44.365z"
+      />
+      <path
+        style="
+          fill: #ffffff;
+          stroke: #000000;
+          stroke-width: 3;
+          stroke-miterlimit: 10;
+        "
+        d="M42.743,79.313H23.066c-1.105,0-2-0.895-2-2
+		V57.635c0-1.105,0.895-2,2-2h19.678c1.105,0,2,0.895,2,2v19.678C44.743,78.417,43.848,79.313,42.743,79.313z"
+      />
+      <path
+        style="
+          fill: #ffffff;
+          stroke: #000000;
+          stroke-width: 3;
+          stroke-miterlimit: 10;
+        "
+        d="M76.935,79.313H57.257c-1.105,0-2-0.895-2-2
+		V57.635c0-1.105,0.895-2,2-2h19.678c1.105,0,2,0.895,2,2v19.678C78.935,78.417,78.039,79.313,76.935,79.313z"
+      />
+    </g>
+  </svg>
+</template>
+
+<script>
+export default {
+    props: {
+        width: {
+            type: [Number, String],
+            default: 100
+        },
+        height: {
+            type: [Number, String],
+            default: 100
+        }
+    }
+}
+</script>

--- a/front/src/components/icons/IconQuestion4taku.vue
+++ b/front/src/components/icons/IconQuestion4taku.vue
@@ -59,6 +59,7 @@
 
 <script>
 export default {
+    name: 'IconQuestion4taku',
     props: {
         width: {
             type: [Number, String],

--- a/front/src/components/icons/IconQuestionAnaume.vue
+++ b/front/src/components/icons/IconQuestionAnaume.vue
@@ -9,6 +9,8 @@
     viewBox="0 0 100 100"
     style="enable-background: new 0 0 100 100"
     xml:space="preserve"
+    :width="width"
+    :height="height"
   >
     <g>
       <path
@@ -76,3 +78,19 @@
     </g>
   </svg>
 </template>
+
+<script>
+export default {
+    name: 'IconQuestionAnaume',
+    props: {
+        width: {
+            type: [Number, String],
+            default: 100
+        },
+        height: {
+            type: [Number, String],
+            default: 100
+        }
+    }
+}
+</script>

--- a/front/src/components/icons/IconQuestionAnaume.vue
+++ b/front/src/components/icons/IconQuestionAnaume.vue
@@ -1,0 +1,78 @@
+<template>
+  <svg
+    version="1.1"
+    id="&#x30EC;&#x30A4;&#x30E4;&#x30FC;_1"
+    xmlns="http://www.w3.org/2000/svg"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    x="0px"
+    y="0px"
+    viewBox="0 0 100 100"
+    style="enable-background: new 0 0 100 100"
+    xml:space="preserve"
+  >
+    <g>
+      <path
+        style="
+          fill: #ffffff;
+          stroke: #000000;
+          stroke-width: 3;
+          stroke-miterlimit: 10;
+        "
+        d="M32.256,47.73H13.432c-1.105,0-2-0.895-2-2
+		V26.907c0-1.105,0.895-2,2-2h18.823c1.105,0,2,0.895,2,2V45.73C34.256,46.834,33.36,47.73,32.256,47.73z"
+      />
+      <path
+        style="
+          fill: #ffffff;
+          stroke: #000000;
+          stroke-width: 3;
+          stroke-miterlimit: 10;
+        "
+        d="M86.568,47.73H67.744c-1.105,0-2-0.895-2-2
+		V26.907c0-1.105,0.895-2,2-2h18.823c1.105,0,2,0.895,2,2V45.73C88.568,46.834,87.672,47.73,86.568,47.73z"
+      />
+      <path
+        style="
+          fill: #ffffff;
+          stroke: #000000;
+          stroke-width: 3;
+          stroke-miterlimit: 10;
+        "
+        d="M32.256,75.093H13.432c-1.105,0-2-0.895-2-2
+		V54.27c0-1.105,0.895-2,2-2h18.823c1.105,0,2,0.895,2,2v18.823C34.256,74.198,33.36,75.093,32.256,75.093z"
+      />
+      <path
+        style="
+          fill: #ffffff;
+          stroke: #000000;
+          stroke-width: 3;
+          stroke-miterlimit: 10;
+        "
+        d="M59.412,75.093H40.588c-1.105,0-2-0.895-2-2
+		V54.27c0-1.105,0.895-2,2-2h18.823c1.105,0,2,0.895,2,2v18.823C61.412,74.198,60.516,75.093,59.412,75.093z"
+      />
+      <circle
+        style="
+          fill: #ffffff;
+          stroke: #000000;
+          stroke-width: 3;
+          stroke-miterlimit: 10;
+        "
+        cx="50"
+        cy="36.318"
+        r="11.412"
+      />
+      <circle
+        style="
+          fill: #ffffff;
+          stroke: #000000;
+          stroke-width: 3;
+          stroke-miterlimit: 10;
+        "
+        cx="77.156"
+        cy="63.682"
+        r="11.412"
+      />
+    </g>
+  </svg>
+</template>

--- a/front/src/components/icons/IconQuestionAnaume.vue
+++ b/front/src/components/icons/IconQuestionAnaume.vue
@@ -81,16 +81,16 @@
 
 <script>
 export default {
-    name: 'IconQuestionAnaume',
-    props: {
-        width: {
-            type: [Number, String],
-            default: 100
-        },
-        height: {
-            type: [Number, String],
-            default: 100
-        }
-    }
+  name: 'IconQuestionAnaume',
+  props: {
+    width: {
+      type: [Number, String],
+      default: 100,
+    },
+    height: {
+      type: [Number, String],
+      default: 100,
+    },
+  },
 }
 </script>

--- a/front/src/components/icons/IconQuestionCollection.vue
+++ b/front/src/components/icons/IconQuestionCollection.vue
@@ -54,16 +54,16 @@
 
 <script>
 export default {
-    name: 'IconQuestionCollection',
-    props: {
-        width: {
-            type: [Number, String],
-            default: 100
-        },
-        height: {
-            type: [Number, String],
-            default: 100
-        }
-    }
+  name: 'IconQuestionCollection',
+  props: {
+    width: {
+      type: [Number, String],
+      default: 100,
+    },
+    height: {
+      type: [Number, String],
+      default: 100,
+    },
+  },
 }
 </script>

--- a/front/src/components/icons/IconQuestionCollection.vue
+++ b/front/src/components/icons/IconQuestionCollection.vue
@@ -1,0 +1,51 @@
+<template>
+  <svg
+    version="1.1"
+    id="&#x30EC;&#x30A4;&#x30E4;&#x30FC;_1"
+    xmlns="http://www.w3.org/2000/svg"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    x="0px"
+    y="0px"
+    viewBox="0 0 100 100"
+    style="enable-background: new 0 0 100 100"
+    xml:space="preserve"
+  >
+    <g>
+      <g>
+        <path
+          style="
+            fill: #ffffff;
+            stroke: #000000;
+            stroke-width: 3;
+            stroke-miterlimit: 10;
+          "
+          d="M81.623,82.311H32.137
+			c-3.78,0-6.844-3.064-6.844-6.844V18.252c0-3.78,3.064-6.844,6.844-6.844h49.486V82.311z"
+        />
+        <path
+          style="
+            fill: #ffffff;
+            stroke: #000000;
+            stroke-width: 3;
+            stroke-miterlimit: 10;
+          "
+          d="M74.706,88.592H25.22
+			c-3.78,0-6.844-3.064-6.844-6.844V24.533c0-3.78,3.064-6.844,6.844-6.844h49.486V88.592z"
+        />
+      </g>
+
+      <rect
+        x="29.814"
+        y="31.859"
+        style="
+          fill: #ffffff;
+          stroke: #000000;
+          stroke-width: 3;
+          stroke-miterlimit: 10;
+        "
+        width="33.455"
+        height="10.093"
+      />
+    </g>
+  </svg>
+</template>

--- a/front/src/components/icons/IconQuestionCollection.vue
+++ b/front/src/components/icons/IconQuestionCollection.vue
@@ -9,6 +9,8 @@
     viewBox="0 0 100 100"
     style="enable-background: new 0 0 100 100"
     xml:space="preserve"
+    :width="width"
+    :height="height"
   >
     <g>
       <g>
@@ -49,3 +51,19 @@
     </g>
   </svg>
 </template>
+
+<script>
+export default {
+    name: 'IconQuestionCollection',
+    props: {
+        width: {
+            type: [Number, String],
+            default: 100
+        },
+        height: {
+            type: [Number, String],
+            default: 100
+        }
+    }
+}
+</script>

--- a/front/src/testdata/question.json
+++ b/front/src/testdata/question.json
@@ -17,7 +17,7 @@
       "タケシ",
       "シンジ"
     ]
-  },
+  },s
   "q_anaume": {
     "questionId": "uuid",
     "name": "天気の問題",

--- a/front/src/testdata/question.json
+++ b/front/src/testdata/question.json
@@ -5,7 +5,8 @@
     "question": "アニメポケットモンスターシリーズに登場する主人公の名前は？",
     "questionType": "4taku",
     "author": {
-      "userId": 0
+      "userId": 0,
+      "displayName": "テストユーザー"
     },
     "createTime": "2000/01/01 00:00:00",
     "updateTime": "2000/01/01 00:00:00",
@@ -23,7 +24,8 @@
     "question": "今日の天気は[]のち[]です。",
     "questionType": "anaume",
     "author": {
-      "userId": 0
+      "userId": 0,
+      "displayName": "テストユーザー"
     },
     "createTime": "2000/01/01 00:00:00",
     "updateTime": "2000/01/01 00:00:00",
@@ -37,18 +39,19 @@
     "collectionId": "uuid",
     "description": "食事の問題集",
     "author": {
-      "userId": 0
+      "userId": 0,
+      "displayName": "テストユーザー"
     },
     "createTime": "2000/01/01 00:00:00",
     "updateTime": "2000/01/01 00:00:00",
-    "questions": [
-      {
+    "questions": [{
         "questionId": "uuid",
         "name": "ポケモンの問題",
         "question": "アニメポケットモンスターシリーズに登場する主人公の名前は？",
         "questionType": "4taku",
         "author": {
-          "userId": 0
+          "userId": 0,
+          "displayName": "テストユーザー"
         },
         "createTime": "2000/01/01 00:00:00",
         "updateTime": "2000/01/01 00:00:00",
@@ -66,7 +69,8 @@
         "question": "今日の天気は[]のち[]です。",
         "questionType": "anaume",
         "author": {
-          "userId": 0
+          "userId": 0,
+          "displayName": "テストユーザー"
         },
         "createTime": "2000/01/01 00:00:00",
         "updateTime": "2000/01/01 00:00:00",

--- a/front/src/testdata/question.json
+++ b/front/src/testdata/question.json
@@ -17,7 +17,7 @@
       "タケシ",
       "シンジ"
     ]
-  },s
+  },
   "q_anaume": {
     "questionId": "uuid",
     "name": "天気の問題",

--- a/front/src/views/ComponentsPreviewPage.vue
+++ b/front/src/views/ComponentsPreviewPage.vue
@@ -1,9 +1,17 @@
 <template>
   <div class="components-preview">
-    <div class="question-preview">
+    <h3>実際に解く問題</h3>
+    <div class="question-compoents">
       <QuestionParent :questionData="sampleQuestionData.q_4taku" />
       <QuestionParent :questionData="sampleQuestionData.q_anaume" />
       <QuestionParent :questionData="sampleQuestionData.q_collection" />
+    </div>
+
+    <h3>ホームに表示される問題プレビュー</h3>
+    <div class="question-preview-components">
+      <QuestionPreview :question="sampleQuestionData.q_4taku" />
+      <QuestionPreview :question="sampleQuestionData.q_anaume" />
+      <QuestionPreview :question="sampleQuestionData.q_collection" />
     </div>
   </div>
 </template>
@@ -11,11 +19,13 @@
 <script>
 // @ is an alias to /src
 import QuestionParent from '@/components/Question.vue'
+import QuestionPreview from '@/components/QuestionPreview.vue'
 
 export default {
   name: 'ComponentsPreviewPage',
   components: {
     QuestionParent,
+    QuestionPreview,
   },
   data() {
     return {
@@ -26,9 +36,13 @@ export default {
 </script>
 
 <style scoped>
-.question-preview {
+.question-compoents {
   display: flex;
-  /*flex-flow: column;*/
-  justify-content: center;
+  justify-content: space-between;
+}
+
+.question-preview-components {
+  display: flex;
+  justify-content: space-between;
 }
 </style>

--- a/go/index.html
+++ b/go/index.html
@@ -1,1 +1,0 @@
-hogehoge


### PR DESCRIPTION
<!--
必ず画面右のメニューからReviewers,Labels,Projectsを設定してください
-->

## 変更点

- プレビューに表示する簡易的なアイコンを作成しました。
- テストデータ、question.jsonに、ユーザー名のデータを追加しました。
- ホーム画面に表示するプレビューを作成しました。
- ComponentsPreviewページにプレビューのサンプルを表示するようにしました。
- 最新のdevelopを取り込みました

## 対応するissue

<!-- closed #issue番号 のように記載してください -->
closed #30 
