### PR TITLE
firebaseのjwtをlocalstorageに保存するようにした

### DIFF
--- a/front/src/views/LoginPage.vue
+++ b/front/src/views/LoginPage.vue
@@ -26,7 +26,9 @@ export default {
     ui.start(firebaseuiAuthContainer, {
       signInOptions: [firebase.auth.EmailAuthProvider.PROVIDER_ID],
       callbacks: {
-        signInSuccessWithAuthResult: () => {
+        signInSuccessWithAuthResult: async (response) => {
+          const idToken = await response.user.getIdToken(true)
+          localStorage.setItem('login_data', idToken.toString())
           this.$router.push('/loginsuccesspreviewpage')
           return false
         },

--- a/front/src/views/LoginSuccessPreviewPage.vue
+++ b/front/src/views/LoginSuccessPreviewPage.vue
@@ -13,6 +13,7 @@ export default {
   methods: {
     async logout() {
       await firebase.auth().signOut()
+      localStorage.removeItem('login_data')
       this.$router.push('/login')
     },
   },


### PR DESCRIPTION
<!--
必ず画面右のメニューからReviewers,Labels,Projectsを設定してください
-->

## 変更点
firebaseから渡されるjwtをlocalstoreageに保存するようにした

jwtがlocalstoreageからログイン時に入ってログアウト時に消える事を`dev tool`で確認して欲しい


## 対応するissue

<!-- closed #issue番号 のように記載してください -->
closed #40 