### PR TITLE
Front/57 Googleアカウントで認証できるようにした

### DIFF
--- a/front/src/views/LoginPage.vue
+++ b/front/src/views/LoginPage.vue
@@ -33,7 +33,6 @@ export default {
         signInSuccessWithAuthResult: async (response) => {
           const idToken = await response.user.getIdToken(true)
           localStorage.setItem('login_data', idToken.toString())
-          this.$router.push('/loginsuccesspreviewpage')
           ui.reset()
           return false
         },

--- a/front/src/views/LoginPage.vue
+++ b/front/src/views/LoginPage.vue
@@ -24,7 +24,10 @@ export default {
       firebaseui.auth.AuthUI.getInstance() ||
       new firebaseui.auth.AuthUI(firebase.auth())
     ui.start(firebaseuiAuthContainer, {
-      signInOptions: [firebase.auth.EmailAuthProvider.PROVIDER_IDy],
+      signInOptions: [
+        firebase.auth.EmailAuthProvider.PROVIDER_ID,
+        firebase.auth.GoogleAuthProvider.PROVIDER_ID,
+      ],
       signInSuccessUrl: 'http://localhost:8080/#/loginsuccesspreviewpage',
       callbacks: {
         signInSuccessWithAuthResult: async (response) => {

--- a/front/src/views/LoginPage.vue
+++ b/front/src/views/LoginPage.vue
@@ -20,31 +20,22 @@ export default {
       // domの生成が出来ていない時はuiの生成をやめる
       return
     }
-    if (
-      firebaseui.auth.AuthUI.getInstance() != null &&
-      firebaseuiAuthContainer.innerHTML == ''
-    ) {
-      // インスタンスがあるのにUIが消えてたら復元する
-      firebaseuiAuthContainer.replaceWith(
-        firebaseui.auth.AuthUI.getInstance().D.a
-      )
-    } else {
-      // UIがなければ作る
-      const ui =
-        firebaseui.auth.AuthUI.getInstance() ||
-        new firebaseui.auth.AuthUI(firebase.auth())
-      ui.start(firebaseuiAuthContainer, {
-        signInOptions: [firebase.auth.EmailAuthProvider.PROVIDER_ID],
-        signInSuccessUrl: 'http://localhost:8080/#/loginsuccesspreviewpage',
-        callbacks: {
-          signInSuccessWithAuthResult: async (response) => {
-            const idToken = await response.user.getIdToken(true)
-            localStorage.setItem('login_data', idToken.toString())
-            return true
-          },
+    const ui =
+      firebaseui.auth.AuthUI.getInstance() ||
+      new firebaseui.auth.AuthUI(firebase.auth())
+    ui.start(firebaseuiAuthContainer, {
+      signInOptions: [firebase.auth.EmailAuthProvider.PROVIDER_IDy],
+      signInSuccessUrl: 'http://localhost:8080/#/loginsuccesspreviewpage',
+      callbacks: {
+        signInSuccessWithAuthResult: async (response) => {
+          const idToken = await response.user.getIdToken(true)
+          localStorage.setItem('login_data', idToken.toString())
+          this.$router.push('/loginsuccesspreviewpage')
+          ui.reset()
+          return false
         },
-      })
-    }
+      },
+    })
   },
 }
 </script>


### PR DESCRIPTION
<!--
必ず画面右のメニューからReviewers,Labels,Projectsを設定してください
-->

## 変更点

* Googleアカウントでログインしようとするとfirebaseのuiの破棄タイミングが早すぎて正しいページにリダイレクトしてくれなかったのでそのバグ修正
* Googleアカウントでログインできるようにした

## 対応するissue

<!-- closed #issue番号 のように記載してください -->
closed #57 
