### PR TITLE
穴埋め問題において選択中のマークが右に少しずれていたものを修正した

### DIFF
--- a/front/src/components/QuestionAnaume.vue
+++ b/front/src/components/QuestionAnaume.vue
@@ -204,7 +204,7 @@ export default {
   position: absolute;
   justify-content: center;
   align-items: center;
-  left: 20px;
+  left: 4%;
 
   color: white;
   background-color: #ffc000;


### PR DESCRIPTION
おそらく、ボーダーの太さの分

<!--
必ず画面右のメニューからReviewers,Labels,Projectsを設定してください
-->

## 変更点
- 選択中マークが少しずれていたので、具体的な値ではなく、画面サイズに適応できるようにした
## 対応するissue

<!-- closed #issue番号 のように記載してください -->
closed #122 
