### PR TITLE
問題集の連続した4択問題において、選択した回答の位置が保存されてしまう問題修正　Front/129

### DIFF
--- a/front/src/components/Question4taku.vue
+++ b/front/src/components/Question4taku.vue
@@ -63,6 +63,7 @@ export default {
         this.$parent.goScorePageAndCheckAnswers(answersData)
       } else {
         this.$parent.storeUserAnswers(answersData)
+        this.selectingQuestionIndex = null
         this.$parent.goNextQuestion()
       }
     },

--- a/front/src/testdata/question.json
+++ b/front/src/testdata/question.json
@@ -246,6 +246,21 @@
           "answers": ["ニワトリ"]
         },
         {
+          "questionName": "(c)肉の問題",
+          "questionID": "aea20877-0e55-11ec-bf6a-0242ac140005",
+          "author": {
+            "userID": "aea20861-0e55-11ec-bf6a-0242ac140005",
+            "userName": "山田孝之"
+          },
+          "questionTag": ["Go", "Dart", "C", "JavaScript"],
+          "questionType": "4taku",
+          "createTime": "1000-01-01 00:00:00.000000",
+          "updateTime": "9999-12-31 23:59:59.999999",
+          "questionBody": "(c)鶏肉はなんの肉？",
+          "values": ["ブタ", "ウシ", "イノシシ", "ニワトリ"],
+          "answers": ["ニワトリ"]
+        },
+        {
           "questionName": "(c)桃太郎の問題",
           "questionID": "aea20877-0e55-11ec-bf6a-0242ac140005",
           "author": {


### PR DESCRIPTION
<!--
必ず画面右のメニューからReviewers,Labels,Projectsを設定してください
-->

## 変更点
- バグ検証のため、テストデータに連続した4択問題を追加しました。
- 4択問題にて、「データ保存->遷移」だったものを「データ保存->初期化->遷移」に変更しました。
  - これにより、回答データのインデックスが保存されてしまい遷移先で回答がすでに選択されている問題に対応しました。

## 対応するissue

<!-- closed #issue番号 のように記載してください --
close #129 