### PR TITLE
テストデータを使用して、ローカル問題検索を行えるようにしました。　Front/141

### DIFF
--- a/front/src/components/Header.vue
+++ b/front/src/components/Header.vue
@@ -14,7 +14,9 @@
       placeholder="問題や問題集を検索する"
       v-model="searchValue"
     />
-    <button @click="searchOnEnter()">検索</button>
+    <button class="header-button" @click="searchOnEnter()">
+      <FontAwesomeIcon icon="search" />
+    </button>
     <button class="header-button" @click="notImplement">
       <FontAwesomeIcon icon="pencil-alt" />
     </button>

--- a/front/src/components/Header.vue
+++ b/front/src/components/Header.vue
@@ -161,7 +161,7 @@ export default {
       let normalWords = []
 
       // 全角の空白を全て半角の空白に変更します。
-      const searchValueHankaku = this.searchValue.replace("　", " ")
+      const searchValueHankaku = this.searchValue.replace('　', ' ')
 
       // 関数を分けたいので、タグと、通常文字を分けます。
       // 空白で区切ります。
@@ -186,8 +186,9 @@ export default {
 
       // 結果を取り出すため、鍵一覧の配列を準備します。
       const questionsFromTagSearchKeys = Object.keys(questionsFromTagSearch)
-      const questionsFromNormalWordSearchKeys =
-        Object.keys(questionsFromNormalWordSearch)
+      const questionsFromNormalWordSearchKeys = Object.keys(
+        questionsFromNormalWordSearch
+      )
 
       // 検索結果の入れ物を用意します。
       // 基本的に重なったキーワードがあった場合、上書きされます。
@@ -224,19 +225,26 @@ export default {
       // ユーザーが検索欄に入力した内容を消します。
       this.searchValue = ''
 
-      const SearchKeysForQueryRaw = [...questionsFromTagSearchKeys, ...questionsFromNormalWordSearchKeys]
+      const SearchKeysForQueryRaw = [
+        ...questionsFromTagSearchKeys,
+        ...questionsFromNormalWordSearchKeys,
+      ]
       let SearchKeysForQuerySafe = {}
-      for (let SearchKeysForQueryRawIndex=0; SearchKeysForQueryRawIndex<SearchKeysForQueryRaw.length; SearchKeysForQueryRawIndex++){
+      for (
+        let SearchKeysForQueryRawIndex = 0;
+        SearchKeysForQueryRawIndex < SearchKeysForQueryRaw.length;
+        SearchKeysForQueryRawIndex++
+      ) {
         const query = SearchKeysForQueryRaw[SearchKeysForQueryRawIndex]
         const safeQuery = encodeURIComponent(query)
-        SearchKeysForQuerySafe[`q${SearchKeysForQueryRawIndex+1}`] = safeQuery
+        SearchKeysForQuerySafe[`q${SearchKeysForQueryRawIndex + 1}`] = safeQuery
       }
 
       this.$router.push({
         path: 'search',
         name: 'SearchPage',
         params: { questionsWithKeyWord: resultQuestions },
-        query: SearchKeysForQuerySafe
+        query: SearchKeysForQuerySafe,
       })
     },
     // -- 検索機能ローカルテスト用関数群:終了 --

--- a/front/src/components/Header.vue
+++ b/front/src/components/Header.vue
@@ -12,7 +12,9 @@
       type="text"
       class="search-box"
       placeholder="問題や問題集を検索する"
+      v-model="searchValue"
     />
+    <button @click="searchOnEnter()">検索</button>
     <button class="header-button" @click="notImplement">
       <FontAwesomeIcon icon="pencil-alt" />
     </button>
@@ -45,8 +47,16 @@ export default {
   data() {
     return {
       isContextMenuOpen: false,
+      searchValue: '',
+      testQuestionData: require('@/testdata/question.json'),
     }
   },
+  computed: {
+    searchSource: function () {
+      return this.testQuestionData.searchSource
+    },
+  },
+
   methods: {
     notImplement() {
       alert('まだないよ')
@@ -57,6 +67,179 @@ export default {
     changeNotifiCationPage() {
       this.$router.push({ path: '/notification' })
     },
+
+    // -- 検索機能ローカルテスト用関数群:開始 --
+
+    // タグで検索
+    searchQuestionsWithTags(tags) {
+      // todo : 問題毎に一致するタグがあるかforで探すとても非効率的な方法なので、検索方法、要検討
+
+      // 検索結果を格納する入れ物を用意します
+      // 何で検索したのか: []問題達
+      let result = {}
+      for (
+        let searchSourceIndex = 0;
+        searchSourceIndex < this.searchSource.length;
+        searchSourceIndex++
+      ) {
+        // 取り出した問題に、名前をつけます
+        const question = this.searchSource[searchSourceIndex]
+        // 一致するタグがあるか探します。
+        for (let tagsIndex = 0; tagsIndex < tags.length; tagsIndex++) {
+          // 取り出したタグに名前をつけます
+          const tagRaw = tags[tagsIndex]
+          const tag = tagRaw.replace('#', '')
+          // もし、タグを含んでいれば、結果に追加します
+          if (question.questionTag.includes(tag)) {
+            // タグが結果に存在するか確認し、なかったら空の配列を設置します
+            if (!Object.prototype.hasOwnProperty.call(result, tagRaw)) {
+              result[tagRaw] = []
+            }
+            // 結果に追加します
+            result[tagRaw].push(question)
+          }
+        }
+      }
+      return result
+    },
+
+    // 通常文字で検索
+    // [ 優先順位 ]
+    // 1. 通常文字に一致するタイトルを持つ問題を探す
+    // 2. 通常文字に一致するquestionBodyを持つ問題を探す
+    searchQuestionsWithNormalWords(normalWords) {
+      // todo : 問題毎に一致する文字列があるかforで探すとても非効率的な方法なので、検索方法、要検討
+      // 部分一致参考 :
+      // https://qiita.com/aqril_1132/items/9f69575bfbcf24bdf7b5#%E9%83%A8%E5%88%86%E4%B8%80%E8%87%B4
+
+      // 検索結果を格納する入れ物を用意します
+      // 何で検索したのか: []問題達
+      let result = {}
+      for (
+        let searchSourceIndex = 0;
+        searchSourceIndex < this.searchSource.length;
+        searchSourceIndex++
+      ) {
+        // 取り出した問題に名前をつけます。
+        const question = this.searchSource[searchSourceIndex]
+        // 通常文字列を取り出し、名前をつけます。
+        for (
+          let normalWordsIndex = 0;
+          normalWordsIndex < normalWords.length;
+          normalWordsIndex++
+        ) {
+          const normalWord = normalWords[normalWordsIndex]
+          // もし、タイトルと通常文字列が部分一致したら、結果に追加します。
+          // また、もし、questionBodyと通常文字列が部分一致したら、結果に追加します。
+
+          // 同じものが、複数存在することを避けるため、else ifで分岐します。
+          if (question.questionName.indexOf(normalWord) > -1) {
+            // 通常文字が結果になかったら空の配列を用意します。
+            if (!Object.prototype.hasOwnProperty.call(result, normalWord)) {
+              result[normalWord] = []
+            }
+            // 結果に追加します。
+            result[normalWord].push(question)
+          } else if (question.questionBody.indexOf(normalWord) > -1) {
+            // 通常文字が結果になかったら空の配列を用意します。
+            if (!Object.prototype.hasOwnProperty.call(result, normalWord)) {
+              result[normalWord] = []
+            }
+            // 結果に追加します。
+            result[normalWord].push(question)
+          }
+        }
+      }
+      return result
+    },
+
+    // 検索欄でエンターが押された時に呼び出される関数
+    searchOnEnter() {
+      // 検索欄から得られた、タグ達を入れる物です。
+      let tags = []
+      // 検索欄から得られた、通常文字達を入れる物です。
+      let normalWords = []
+
+      // 全角の空白を全て半角の空白に変更します。
+      const searchValueHankaku = this.searchValue.replace("　", " ")
+
+      // 関数を分けたいので、タグと、通常文字を分けます。
+      // 空白で区切ります。
+
+      const searchValueSplit = searchValueHankaku.split(' ')
+      for (let i = 0; i < searchValueSplit.length; i++) {
+        // 区切られた中身を取り出し、使いやすいように名前をつけます。
+        const word = searchValueSplit[i]
+        // もし、一番最初の文字が「#」ならタグです。
+        // それ以外は通常文字です。
+        if (word[0] == '#') {
+          tags.push(word)
+        } else {
+          normalWords.push(word)
+        }
+      }
+
+      // 実際に検索を行います。
+      const questionsFromTagSearch = this.searchQuestionsWithTags(tags)
+      const questionsFromNormalWordSearch =
+        this.searchQuestionsWithNormalWords(normalWords)
+
+      // 結果を取り出すため、鍵一覧の配列を準備します。
+      const questionsFromTagSearchKeys = Object.keys(questionsFromTagSearch)
+      const questionsFromNormalWordSearchKeys =
+        Object.keys(questionsFromNormalWordSearch)
+
+      // 検索結果の入れ物を用意します。
+      // 基本的に重なったキーワードがあった場合、上書きされます。
+      let resultQuestions = {}
+
+      for (
+        let questionsFromTagSearchKeysIndex = 0;
+        questionsFromTagSearchKeysIndex < questionsFromTagSearchKeys.length;
+        questionsFromTagSearchKeysIndex++
+      ) {
+        // 鍵を取り出し、名前をつけます。
+        const questionsFromTagSearchKey =
+          questionsFromTagSearchKeys[questionsFromTagSearchKeysIndex]
+        // 各々の検索結果を全体の検索結果に統合します。
+        resultQuestions[questionsFromTagSearchKey] =
+          questionsFromTagSearch[questionsFromTagSearchKey]
+      }
+
+      for (
+        let questionsFromNormalWordSearchKeysIndex = 0;
+        questionsFromNormalWordSearchKeysIndex <
+        questionsFromNormalWordSearchKeys.length;
+        questionsFromNormalWordSearchKeysIndex++
+      ) {
+        // 取り出して、名前をつけます。
+        const questionsFromNormalWordSearchKey =
+          questionsFromNormalWordSearchKeys[
+            questionsFromNormalWordSearchKeysIndex
+          ]
+        resultQuestions[questionsFromNormalWordSearchKey] =
+          questionsFromNormalWordSearch[questionsFromNormalWordSearchKey]
+      }
+
+      // ユーザーが検索欄に入力した内容を消します。
+      this.searchValue = ''
+
+      const SearchKeysForQueryRaw = [...questionsFromTagSearchKeys, ...questionsFromNormalWordSearchKeys]
+      let SearchKeysForQuerySafe = {}
+      for (let SearchKeysForQueryRawIndex=0; SearchKeysForQueryRawIndex<SearchKeysForQueryRaw.length; SearchKeysForQueryRawIndex++){
+        const query = SearchKeysForQueryRaw[SearchKeysForQueryRawIndex]
+        const safeQuery = encodeURIComponent(query)
+        SearchKeysForQuerySafe[`q${SearchKeysForQueryRawIndex+1}`] = safeQuery
+      }
+
+      this.$router.push({
+        path: 'search',
+        name: 'SearchPage',
+        params: { questionsWithKeyWord: resultQuestions },
+        query: SearchKeysForQuerySafe
+      })
+    },
+    // -- 検索機能ローカルテスト用関数群:終了 --
 
     toggleContextMenu() {
       this.isContextMenuOpen = !this.isContextMenuOpen

--- a/front/src/router/index.js
+++ b/front/src/router/index.js
@@ -7,6 +7,7 @@ import ScorePage from '../views/ScorePage.vue'
 import NotifiCationPage from '../views/NotifiCationPage.vue'
 import LoginPage from '../views/LoginPage'
 import LoginSuccessPreviewPage from '../views/LoginSuccessPreviewPage'
+import SearchPage from '../views/SearchPage.vue'
 
 import firebase from 'firebase/compat/app'
 import 'firebase/compat/auth'
@@ -60,6 +61,12 @@ const routes = [
     name: 'LoginSuccessPreviewPage',
     component: LoginSuccessPreviewPage,
     meta: { requiresAuth: true },
+  },
+  {
+    path: '/search',
+    name: 'SearchPage',
+    component: SearchPage,
+    props: true,
   },
 ]
 

--- a/front/src/testdata/question.json
+++ b/front/src/testdata/question.json
@@ -36,8 +36,7 @@
     },
     "createTime": "2000/01/01 00:00:00",
     "updateTime": "2000/01/01 00:00:00",
-    "questions": [
-      {
+    "questions": [{
         "questionId": "uuid",
         "name": "ポケモンの問題",
         "question": "アニメポケットモンスターシリーズに登場する主人公の名前は？",
@@ -66,8 +65,7 @@
       }
     ]
   },
-  "multipleProblemSamples": [
-    {
+  "multipleProblemSamples": [{
       "questionID": "aea20873-0e55-11ec-bf6a-0242ac140005",
       "author": {
         "userID": "aea20225-0e55-11ec-bf6a-0242ac140005",
@@ -229,8 +227,7 @@
         "userID": "aea20861-0e55-11ec-bf6a-0242ac140005",
         "userName": "山田孝之"
       },
-      "questions": [
-        {
+      "questions": [{
           "questionName": "(c)肉の問題",
           "questionID": "aea20877-0e55-11ec-bf6a-0242ac140005",
           "author": {
@@ -266,5 +263,231 @@
       "createTime": "9999-12-31 23:59:59.999999",
       "updateTime": "9999-12-31 23:59:59.999999"
     }
-  }
+  },
+  "searchSource": [{
+    "questionID": "e6a472f7-126e-11ec-b3ec-0242ac120004",
+    "author": {
+      "userID": "e6a46f5a-126e-11ec-b3eb-0242ac120004",
+      "userName": "hoge"
+    },
+    "questionName": "コード進行1",
+    "questionTag": ["音楽", "音楽記号", "コード理論"],
+    "questionType": "4taku",
+    "createTime": "2021-08-31 15:30:57.499391",
+    "updateTime": "2021-08-31 18:33:24.299391",
+    "questionBody": "C,G,Am,Em,F,C,F,Gのコード進行は?",
+    "values": ["カノン進行", "J-POP王道進行", "小室進行", "イチロクニーゴー"],
+    "answers": ["カノン進行"],
+    "color": "#A2F1FF"
+  }, {
+    "questionID": "e6a4730b-126e-11ec-b3ec-0242ac120004",
+    "author": {
+      "userID": "e6a46f5a-126e-11ec-b3eb-0242ac120004",
+      "userName": "hoge"
+    },
+    "questionName": "音楽用語1",
+    "questionTag": ["音楽", "音楽用語"],
+    "questionType": "anaume",
+    "createTime": "2021-08-31 15:36:27.135791",
+    "updateTime": "2021-08-31 19:32:24.359291",
+    "questionBody": "Poco Allegro con affettoの意味は?",
+    "values": ["やや[]く[]こめて"],
+    "answers": ["はや", "愛情"],
+    "color": "#FFB4C5"
+  }, {
+    "questionID": "e6a4730c-126e-11ec-b3ec-0242ac120004",
+    "author": {
+      "userID": "e6a46f5a-126e-11ec-b3eb-0242ac120004",
+      "userName": "hoge"
+    },
+    "questionName": "音楽用語2",
+    "questionTag": ["音楽", "音楽用語"],
+    "questionType": "anaume",
+    "createTime": "2021-09-01 02:15:30.321691",
+    "updateTime": "2021-09-01 04:18:21.321691",
+    "questionBody": "più animato con passioneの意味は?",
+    "values": ["[]的にやや[]と[]く"],
+    "answers": ["情熱", "生き生きと", "はや"],
+    "color": "#9AF7B6"
+  }, {
+    "questionID": "e6a4730d-126e-11ec-b3ec-0242ac120004",
+    "author": {
+      "userID": "e6a46f5a-126e-11ec-b3eb-0242ac120004",
+      "userName": "hoge"
+    },
+    "questionName": "C言語1",
+    "questionTag": ["プログラミング言語", "C"],
+    "questionType": "4taku",
+    "createTime": "2021-09-01 05:32:47.401391",
+    "updateTime": "2021-09-01 10:24:25.401391",
+    "questionBody": "intは何型?",
+    "values": ["整数型", "文字型", "実数型", "構造体"],
+    "answers": ["整数型"],
+    "color": "#FFE796"
+  }, {
+    "questionID": "e6a4730e-126e-11ec-b3ec-0242ac120004",
+    "author": {
+      "userID": "e6a472f4-126e-11ec-b3eb-0242ac120004",
+      "userName": "huga"
+    },
+    "questionName": "ミラーリングについて",
+    "questionTag": ["資格", "基本情報", "IT"],
+    "questionType": "4taku",
+    "createTime": "2021-09-01 15:20:12.821491",
+    "updateTime": "2021-09-01 22:34:51.821491",
+    "questionBody": "ミラーリングを用いることで，信頼性を高め障害発生時にデータ復元を行う方式はどれか？",
+    "values": ["RAID1", "RAID2", "RAID3", "RAID4"],
+    "answers": ["RAID1"],
+    "color": "#D4D9F2"
+  }, {
+    "questionID": "e6a4730f-126e-11ec-b3ec-0242ac120004",
+    "author": {
+      "userID": "e6a472f4-126e-11ec-b3eb-0242ac120004",
+      "userName": "huga"
+    },
+    "questionName": "計算誤差について",
+    "questionTag": ["資格", "基本情報", "IT"],
+    "questionType": "4taku",
+    "createTime": "2021-09-01 15:25:32.135491",
+    "updateTime": "2021-09-01 22:57:12.135491",
+    "questionBody": "値がほぼ等しい浮動小数点同士の計算により，有効桁数が減ってしまうのはどれか？",
+    "values": ["桁落ち", "丸め誤差", "情報落ち", "桁あふれ誤差"],
+    "answers": ["桁落ち"],
+    "color": "#A2F1FF"
+  }, {
+    "questionID": "e6a47310-126e-11ec-b3ec-0242ac120004",
+    "author": {
+      "userID": "e6a472f4-126e-11ec-b3eb-0242ac120004",
+      "userName": "huga"
+    },
+    "questionName": "記憶方式について",
+    "questionTag": ["資格", "基本情報", "IT"],
+    "questionType": "4taku",
+    "createTime": "2021-09-01 18:49:32.632182",
+    "updateTime": "2021-09-01 20:32:47.632182",
+    "questionBody": "仮想記憶空間と実記憶空間を，固定長の領域に区切り対応させる管理方式はどれか？",
+    "values": ["動的再配置", "メモリインタリーブ", "ページング方式", "ブロック化"],
+    "answers": ["ページング方式"],
+    "color": "#FFB4C5"
+  }, {
+    "questionID": "e6a47312-126e-11ec-b3ec-0242ac120004",
+    "author": {
+      "userID": "e6a472f4-126e-11ec-b3eb-0242ac120004",
+      "userName": "huga"
+    },
+    "questionName": "攻撃手法について",
+    "questionTag": ["資格", "基本情報", "IT"],
+    "questionType": "4taku",
+    "createTime": "2021-09-01 23:20:18.311491",
+    "updateTime": "2021-09-02 22:43:32.311491",
+    "questionBody": "パスワードを解読する手法として，総当たりで調べるのはどれか？",
+    "values": ["線形解読法", "ブルートフォース攻撃", "差分解読法", "関連鍵攻撃"],
+    "answers": ["ブルートフォース攻撃"],
+    "color": ""
+  }, {
+    "questionID": "e6a47313-126e-11ec-b3ec-0242ac120004",
+    "author": {
+      "userID": "e6a472f4-126e-11ec-b3eb-0242ac120004",
+      "userName": "huga"
+    },
+    "questionName": "英文法",
+    "questionTag": ["英語", "英文法", "TOEIC"],
+    "questionType": "4taku",
+    "createTime": "2021-09-02 22:19:32.231891",
+    "updateTime": "2021-09-02 23:15:21.231891",
+    "questionBody": "The International Peace Conference ___ as planned of Saturday.",
+    "values": ["concluded", "held", "achieved", "invited"],
+    "answers": ["concluded"],
+    "color": "#9AF7B6"
+  }, {
+    "questionID": "e6a47314-126e-11ec-b3ec-0242ac120004",
+    "author": {
+      "userID": "e6a472f4-126e-11ec-b3eb-0242ac120004",
+      "userName": "huga"
+    },
+    "questionName": "英文法",
+    "questionTag": ["英語", "英文法", "TOEIC"],
+    "questionType": "4taku",
+    "createTime": "2021-09-03 19:13:32.102491",
+    "updateTime": "2021-09-03 21:45:33.102491",
+    "questionBody": "The new guidelines regarding jury duty should be ___ to strictly.",
+    "values": ["respected", "adhered", "willing", "set"],
+    "answers": ["adhered"],
+    "color": "#FFE796"
+  }, {
+    "questionID": "e6a47315-126e-11ec-b3ec-0242ac120004",
+    "author": {
+      "userID": "e6a472f4-126e-11ec-b3eb-0242ac120004",
+      "userName": "huga"
+    },
+    "questionName": "英文法",
+    "questionTag": ["英語", "英文法", "TOEIC"],
+    "questionType": "4taku",
+    "createTime": "2021-09-04 12:43:42.502491",
+    "updateTime": "2021-09-04 19:21:11.502491",
+    "questionBody": "Our new facility ___ right across from the city's new convention center.",
+    "values": ["is located", "will locate", "is to locate", "had located"],
+    "answers": ["is located"],
+    "color": "#D4D9F2"
+  }, {
+    "questionID": "e6a47316-126e-11ec-b3ec-0242ac120004",
+    "author": {
+      "userID": "e6a472f4-126e-11ec-b3eb-0242ac120004",
+      "userName": "huga"
+    },
+    "questionName": "英文法",
+    "questionTag": ["英語", "英文法", "TOEIC"],
+    "questionType": "4taku",
+    "createTime": "2021-09-06 18:13:29.319491",
+    "updateTime": "2021-09-06 23:43:11.319491",
+    "questionBody": "A sudden drop in sales would ___ cuts in production and employment.",
+    "values": ["necessitate", "necessary", "necessity", "necessarily"],
+    "answers": ["necessitate"],
+    "color": "#A2F1FF"
+  }, {
+    "questionID": "e6a47319-126e-11ec-b3ec-0242ac120004",
+    "author": {
+      "userID": "e6a472f4-126e-11ec-b3eb-0242ac120004",
+      "userName": "huga"
+    },
+    "questionName": "英単語",
+    "questionTag": ["英語", "英単語", "TOEIC"],
+    "questionType": "4taku",
+    "createTime": "2021-09-07 20:12:12.812391",
+    "updateTime": "2021-09-08 18:15:29.319491",
+    "questionBody": "protractor の意味は？",
+    "values": ["コンパス", "分度器", "消しゴム", "黒板消し"],
+    "answers": ["分度器"],
+    "color": "#FFB4C5"
+  }, {
+    "questionID": "e6a4731a-126e-11ec-b3ec-0242ac120004",
+    "author": {
+      "userID": "e6a472f4-126e-11ec-b3eb-0242ac120004",
+      "userName": "huga"
+    },
+    "questionName": "英単語",
+    "questionTag": ["英語", "英単語", "TOEIC"],
+    "questionType": "4taku",
+    "createTime": "2021-09-08 03:41:22.352390",
+    "updateTime": "2021-09-08 14:22:45.352390",
+    "questionBody": "apprentice の意味は？",
+    "values": ["人類", "謝る", "初心者", "食欲"],
+    "answers": ["初心者"],
+    "color": "#9AF7B6"
+  }, {
+    "questionID": "e6a4731b-126e-11ec-b3ec-0242ac120004",
+    "author": {
+      "userID": "e6a472f4-126e-11ec-b3eb-0242ac120004",
+      "userName": "huga"
+    },
+    "questionName": "英単語",
+    "questionTag": ["英語", "英単語", "TOEIC"],
+    "questionType": "4taku",
+    "createTime": "2021-09-09 23:22:42.292391",
+    "updateTime": "2021-09-10 11:34:45.292391",
+    "questionBody": "photosynthesis の意味は？",
+    "values": ["写真", "定説", "映像", "光合成"],
+    "answers": ["光合成"],
+    "color": "#FFE796"
+  }]
 }

--- a/front/src/views/SearchPage.vue
+++ b/front/src/views/SearchPage.vue
@@ -2,7 +2,7 @@
   <div>
     <!-- <h3>{{searchResultKeys}}</h3> -->
     <div v-if="searchResultKeys.length == 0">
-        <h2 class="no-result">結果なし</h2>
+      <h2 class="no-result">結果なし</h2>
     </div>
     <div v-for="searchResultKey in searchResultKeys" :key="searchResultKey">
       <PostList
@@ -37,10 +37,10 @@ export default {
 
 <style scoped>
 .no-result {
-    /* display: flex;
+  /* display: flex;
     justify-content: center;
     align-content: center; */
-    top: 50%;
-    left: 50%;;
+  top: 50%;
+  left: 50%;
 }
 </style>

--- a/front/src/views/SearchPage.vue
+++ b/front/src/views/SearchPage.vue
@@ -1,0 +1,46 @@
+<template>
+  <div>
+    <!-- <h3>{{searchResultKeys}}</h3> -->
+    <div v-if="searchResultKeys.length == 0">
+        <h2 class="no-result">結果なし</h2>
+    </div>
+    <div v-for="searchResultKey in searchResultKeys" :key="searchResultKey">
+      <PostList
+        :title="searchResultKey"
+        :postDataList="questionsWithKeyWord[searchResultKey]"
+      />
+    </div>
+  </div>
+</template>
+
+<script>
+import PostList from '@/components/QuestionAndCollectionPostList'
+
+export default {
+  name: 'SearchResultPage',
+  props: {
+    questionsWithKeyWord: {
+      type: Object,
+      required: true,
+    },
+  },
+  components: {
+    PostList,
+  },
+  computed: {
+    searchResultKeys: function () {
+      return Object.keys(this.questionsWithKeyWord)
+    },
+  },
+}
+</script>
+
+<style scoped>
+.no-result {
+    /* display: flex;
+    justify-content: center;
+    align-content: center; */
+    top: 50%;
+    left: 50%;;
+}
+</style>


### PR DESCRIPTION
<!--
必ず画面右のメニューからReviewers,Labels,Projectsを設定してください
-->

## 変更点
- testdata/questionのsearchSourceから問題検索をできるようにしました。
- 検索画面を追加しました。
- Goのハンドルから返却されるデータをテストデータに写しました。
## 対応するissue

<!-- closed #issue番号 のように記載してください -->
closed #141 
