### PR TITLE
連続した穴埋め問題において、一つ前に選択されていたものが、次の問題でも選択された状態になってしまうバグを修正Front/144

### DIFF
--- a/front/src/components/QuestionAnaume.vue
+++ b/front/src/components/QuestionAnaume.vue
@@ -158,6 +158,11 @@ export default {
           this.$parent.goScorePageAndCheckAnswers(answersData)
         } else {
           this.$parent.storeUserAnswers(answersData)
+          for (let i = 0; i < this.question.answers.length; i++) {
+            this.questionSplit[this.squareBracketsIndexs[i]] =
+              '[ ' + (i + 1) + ' ]'
+          }
+          this.selectingIndexs = []
           this.$parent.goNextQuestion()
         }
       }

--- a/front/src/testdata/question.json
+++ b/front/src/testdata/question.json
@@ -261,6 +261,23 @@
             "桃太郎は[]から生まれ、おじいさんと[]に育てられ、[]を退治した"
           ],
           "answers": ["桃", "おばあさん", "鬼"]
+        },
+        {
+          "questionName": "(c)桃太郎の問題",
+          "questionID": "aea20877-0e55-11ec-bf6a-0242ac140005",
+          "author": {
+            "userID": "aea20861-0e55-11ec-bf6a-0242ac140005",
+            "userName": "田中"
+          },
+          "questionTag": ["Go", "Dart", "C", "JavaScript"],
+          "questionType": "anaume",
+          "createTime": "1000-01-01 00:00:00.000000",
+          "updateTime": "9999-12-31 23:59:59.999999",
+          "questionBody": "(c)以下の空欄を埋めなさい",
+          "values": [
+            "桃太郎は[]から生まれ、おじいさんと[]に育てられ、[]を退治した"
+          ],
+          "answers": ["桃", "おばあさん", "鬼"]
         }
       ],
       "createTime": "9999-12-31 23:59:59.999999",


### PR DESCRIPTION
<!--
必ず画面右のメニューからReviewers,Labels,Projectsを設定してください
-->

## 変更点
- 遷移において「データ保存」-> 「遷移」となっていたものを「データ保存」-> 「データ初期化」-> 「遷移」とし、前のデータが残らないようにしました。
- testdata/questionに連続した問題を追加し、テストできるようにしました。

## 対応するissue

<!-- closed #issue番号 のように記載してください -->
closed #144 
